### PR TITLE
Fix for OSX packaging info added before it being merged into synfig.

### DIFF
--- a/docs/packaging/Packaging using CMake.rst
+++ b/docs/packaging/Packaging using CMake.rst
@@ -28,15 +28,6 @@ A *.deb* package for Synfig can be made by using the following code.
 
     $ cpack -G DEB
 
-OSX
----
-
-A *.dmg* package for Synfig can be made by using the following code.
-
-.. code:: bash
-
-    $ cpack -G DragNDrop
-
 Windows
 -------
 


### PR DESCRIPTION
Packaging info for OSX was added before it was merged into master. The PR is still active [here](https://github.com/synfig/synfig/pull/1630). So this is inaccurate. It can be added once it is implemented. 