### PR TITLE
Fixing the needed command to run Synfig using Cmake.

### DIFF
--- a/docs/building/Building using CMake.rst
+++ b/docs/building/Building using CMake.rst
@@ -86,5 +86,5 @@ Once this is completed successfully, you can run Synfig by.
 
 .. code:: bash
 
-    $ ./cmake-build-msys/output/bin/synfigstudio.exe
+    $ ./cmake-build-msys/output/Release/bin/synfigstudio.exe
 


### PR DESCRIPTION
At the end of running of 
"$ ./2-build-msys-cmake.sh"
I was prompted with "[897/897] Linking CXX executable output\Release\bin\synfigstudio.exe"
then i followed the guide to build the program which was to execute 
"$ ./cmake-build-msys/output/bin/synfigstudio.exe"
but it gaave an error saying 
"bash: ./cmake-build-msys/output/bin/synfigstudio.exe: No such file or directory"
so I figured out that in fact the location was wrong and fixed it to 
"$ ./cmake-build-msys/output/Release/bin/synfigstudio.exe"
and the program started successfully.