### PR TITLE
Updated "Better Shortcuts" status from DRAFT to COMPLETED

### DIFF
--- a/docs/projects/shortcuts.rst
+++ b/docs/projects/shortcuts.rst
@@ -1,6 +1,6 @@
 .. _shortcuts-project:
 
-Better Shortcuts [DRAFT]
+Better Shortcuts [COMPLETED]
 =====================================================
 
 This project is a resolution for discussion in `issue 1336 <https://github.com/synfig/synfig/issues/1336>`_.


### PR DESCRIPTION
I proposed to delete the page a year ago. But noticed that older project ideas have been marked as "COMPLETED" instead of deleting them so I thought I'd do the same for this shortcuts page too.

fix  #89