### PR TITLE
Fix typo 'you-username' to 'your-username' in file 'contribution guidelines.rst'

### DIFF
--- a/docs/community/contribution guidelines.rst
+++ b/docs/community/contribution guidelines.rst
@@ -46,7 +46,7 @@ Fork the project by clicking “Fork” in the top right corner of synfig/synfig
 Clone the repository locally 
 ::
 
-  git clone https://github.com/<you-username>/synfig
+  git clone https://github.com/<your-username>/synfig
 
 Create a new, descriptively named branch to contain your change
 ::


### PR DESCRIPTION
Fixed a typo _you-username_ to _your-username_ in the file 'contribution guidelines.rst' under the subheading **Contributing code changes**