### PR TITLE
Remove android project from GSOC ideas.

### DIFF
--- a/docs/gsoc/2026/ideas.rst
+++ b/docs/gsoc/2026/ideas.rst
@@ -9,40 +9,6 @@ This year we plan to apply to Google Summer of Code. Currently we are looking fo
 Projects Ideas
 --------------
 
-Synfig Android Version (350hrs)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-**Description:**
-This project aims at providing a solid ground for a Synfig Android version. It aims to do so through two main parts.
-
-1- Prototype UI (Using Qt for android) that uses synfigapp and -in turn- synfig-core
-
-There are two main goals here:
-1. To have a basic android UI for synfig working. 
-2. While making this prototype certain parts of the synfig api would be fixed. Which would make SynfigApp and Synfig-Core able to be used with any other UI not just the current gtkmm UI (synfig-studio).
-
-2- Add more features to the UI
-Synfig is quite a huge application. Most likely this app would start with only very basic needed synfig features added. Then gradually adding more features from synfig-studio to the new prototype UI.
-
-**Where to begin:**
-
-1. Start out by understanding and gathering the basic features for animation in synfig. In your proposal include these features and expand on how you plan to include them. 
-2. Research the available mobile/tablet animation apps and prototype a ui design using any ui design software (e.g. canva). This is not required but it will definetly help your proposal.
-
-
-**Expected outcome**
-
-- Prototype Synfig Android Version
-- Improved synfig-app and (possibly) synfig-core that can work with any other UI.
-
-**Difficulty:** Medium/High
-
-**Skills required/preferred:** C++, gtkmm, Qt, using Qt for Android
-
-**Possible mentor(s):** `Mohamed Adham <https://github.com/mohamedAdhamc>`_ , `Rodolfo Ribeiro <https://github.com/rodolforg>`_
-
-**Expected size of project:** 350 hours
-
 Exporter to Spine file format (175hrs)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
@ice0, @rodolforg unfortunately I think as @BobSynfig said, android is indeed moving in a direction that would make it hard for this project to still make sense. Especially given how big of an effort this project would actually need beyond the GSOC timeframe. If you have any other thoughts though please let me know. 

p.s.
I will also try to think of (or refetch) some other ideas and propose them. 